### PR TITLE
#14 Change links of pokemon icons

### DIFF
--- a/app/scripts/modules/pokebank.module.js
+++ b/app/scripts/modules/pokebank.module.js
@@ -11,7 +11,7 @@ $(function() {
       };
 
       var icons = {
-        pokemon: function(id){ return 'http://pokeapi.co/media/sprites/pokemon/' + id + '.png'; }
+        pokemon: function(id){ return 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/' + id + '.png'; }
       };
 
       return {


### PR DESCRIPTION
Seems to work with the new links:

<img width="1592" alt="screen shot 2016-08-14 at 00 20 00" src="https://cloud.githubusercontent.com/assets/8037110/17645944/eb2f9164-61b4-11e6-9207-0396e6cfa0d0.png">

Should fix #14 
